### PR TITLE
refactor(models): update User-Role association foreign key configuration

### DIFF
--- a/_app/server/.models/User.js
+++ b/_app/server/.models/User.js
@@ -49,8 +49,9 @@ const User = sequelize.define(
     },
     roleId: {
       type: DataTypes.UUID,
+      field: 'role_id',
       references: {
-        model: 'Roles',
+        model: 'roles',
         key: 'id'
       }
     },

--- a/_app/server/.models/index.js
+++ b/_app/server/.models/index.js
@@ -6,13 +6,12 @@ const Role = require('./Role');
 
 // User and Role association
 User.belongsTo(Role, {
-    foreignKey: {
-        name: 'fk_user_role',
-        field: 'roleId'
-    }
+    foreignKey: 'role_id'
 });
 
-Role.hasMany(User);
+Role.hasMany(User, {
+    foreignKey: 'role_id'
+});
 
 // User and Task association
 Task.belongsTo(User, {


### PR DESCRIPTION
- Modify User and Role model associations with simplified foreign key
- Use 'role_id' as the consistent foreign key for both model associations
- Streamline model relationship configuration