### PR TITLE
fix: Move build dependencies to dependencies for Heroku deployment

### DIFF
--- a/_app/client/package.json
+++ b/_app/client/package.json
@@ -16,13 +16,16 @@
     "axios": "^1.7.9",
     "pinia": "^2.3.1",
     "vue": "^3.4.15",
-    "vue-router": "^4.5.0"
+    "vue-router": "^4.5.0",
+    "vue-tsc": "^1.8.27",
+    "typescript": "~5.3.3",
+    "vite": "^6.0.11",
+    "@vitejs/plugin-vue": "^5.2.1"
   },
   "devDependencies": {
     "@eslint/js": "^8.56.0",
     "@playwright/test": "^1.49.1",
     "@types/node": "^20.11.17",
-    "@vitejs/plugin-vue": "^5.2.1",
     "@vitejs/plugin-vue-jsx": "^4.1.1",
     "@vitest/eslint-plugin": "1.1.25",
     "@vue/eslint-config-prettier": "^10.1.0",
@@ -33,10 +36,7 @@
     "eslint-plugin-vue": "^9.32.0",
     "jsdom": "^24.0.0",
     "prettier": "^3.4.2",
-    "typescript": "~5.3.3",
-    "vite": "^6.0.11",
     "vite-plugin-vue-devtools": "^7.7.0",
-    "vitest": "^3.0.2",
-    "vue-tsc": "^1.8.27"
+    "vitest": "^3.0.2"
   }
 }


### PR DESCRIPTION
This pull request includes updates to the `package.json` file for the `_app/client` project. The changes primarily involve moving some dependencies from the `devDependencies` section to the `dependencies` section.

Dependency updates:

* Moved `@vitejs/plugin-vue` from `devDependencies` to `dependencies`.
* Moved `vue-tsc`, `typescript`, and `vite` from `devDependencies` to `dependencies`. [[1]](diffhunk://#diff-ff31d86dcf492f3a165324bc904e679332c1e563fc86cdc9acdf799681fad9fcL19-L25) [[2]](diffhunk://#diff-ff31d86dcf492f3a165324bc904e679332c1e563fc86cdc9acdf799681fad9fcL36-R40)