### PR TITLE
fix: Simplify TypeScript configuration for Heroku deployment

### DIFF
--- a/_app/client/package.json
+++ b/_app/client/package.json
@@ -13,14 +13,15 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "@vitejs/plugin-vue": "^5.2.1",
+    "@vue/tsconfig": "^0.5.1",
     "axios": "^1.7.9",
     "pinia": "^2.3.1",
-    "vue": "^3.4.15",
-    "vue-router": "^4.5.0",
-    "vue-tsc": "^1.8.27",
     "typescript": "~5.3.3",
     "vite": "^6.0.11",
-    "@vitejs/plugin-vue": "^5.2.1"
+    "vue": "^3.4.15",
+    "vue-router": "^4.5.0",
+    "vue-tsc": "^1.8.27"
   },
   "devDependencies": {
     "@eslint/js": "^8.56.0",
@@ -30,7 +31,6 @@
     "@vitest/eslint-plugin": "1.1.25",
     "@vue/eslint-config-prettier": "^10.1.0",
     "@vue/test-utils": "^2.4.6",
-    "@vue/tsconfig": "^0.5.1",
     "eslint": "^8.56.0",
     "eslint-plugin-playwright": "^2.1.0",
     "eslint-plugin-vue": "^9.32.0",

--- a/_app/client/tsconfig.json
+++ b/_app/client/tsconfig.json
@@ -1,22 +1,29 @@
 {
-  "extends": "@vue/tsconfig/tsconfig.dom.json",
-  "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
-  "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
-    "composite": true,
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"]
-    },
-    "types": ["node"],
-    "allowJs": true,
-    "checkJs": false,
-    "jsx": "preserve",
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
     "strict": false,
+    "jsx": "preserve",
+    "importHelpers": true,
     "skipLibCheck": true,
-    "esModuleInterop": true
-  }
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "sourceMap": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "lib": ["esnext", "dom", "dom.iterable", "scripthost"],
+    "types": ["node", "vite/client"],
+    "allowJs": true,
+    "checkJs": false
+  },
+  "include": [
+    "env.d.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/**/*.vue"
+  ],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
This pull request includes several changes to the `package.json` and `tsconfig.json` files in the `_app/client` directory. The main changes involve updating dependencies and modifying TypeScript configuration options.

### Dependency Updates:

* Added `@vitejs/plugin-vue` and `@vue/tsconfig` to the `dependencies` section and removed them from the `devDependencies` section in `package.json`. [[1]](diffhunk://#diff-ff31d86dcf492f3a165324bc904e679332c1e563fc86cdc9acdf799681fad9fcR16-R24) [[2]](diffhunk://#diff-ff31d86dcf492f3a165324bc904e679332c1e563fc86cdc9acdf799681fad9fcL33)

### TypeScript Configuration:

* Updated the `tsconfig.json` file to include new compiler options such as `importHelpers`, `allowSyntheticDefaultImports`, and `sourceMap`. Also, restructured the `include` and `exclude` arrays to better match the project structure.