### PR TITLE
fix: Add memory limit configuration for Heroku deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: cd _app/server && NODE_OPTIONS='--max_old_space_size=2048' npm start

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "devClient": "cd _app/client && npm run dev",
     "start": "npm run build && cd _app/server && node index.js",
     "migrate": "cd _app/server && npm run migrate",
-    "heroku-postbuild": "cd _app/client && npm install && npm run build && cd ../server && npm install",
+    "heroku-postbuild": "export NODE_OPTIONS='--max_old_space_size=2048' && cd _app/client && npm install && npm run build && cd ../server && npm install",
     "heroku:log": "heroku logs --tail --app ilytat-organizer"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request includes changes to manage memory usage for Node.js processes by setting the `NODE_OPTIONS` environment variable. The most important changes are:

Memory management improvements:

* [`Procfile`](diffhunk://#diff-0a99231995da379e7aebabe76c9d849a23737a42c3b3a8994043e2aa80958424R1): Added `NODE_OPTIONS='--max_old_space_size=2048'` to increase the maximum memory allocation for the Node.js process.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L8-R8): Modified the `heroku-postbuild` script to include `NODE_OPTIONS='--max_old_space_size=2048'` to ensure sufficient memory allocation during the build process.- Added Procfile with NODE_OPTIONS memory limit
- Updated heroku-postbuild script with increased memory limit
- Set max_old_space_size to 2048MB